### PR TITLE
mnist: show accuracy

### DIFF
--- a/mnist/mnist.jl
+++ b/mnist/mnist.jl
@@ -2,13 +2,16 @@ using Flux, MNIST
 using Flux: onehotbatch, argmax, mse, throttle
 using Base.Iterators: repeated
 
+info("Loading train data")
 x, y = traindata()
 y = onehotbatch(y, 0:9)
 
+info("Building model")
 m = Chain(
   Dense(28^2, 32, relu),
   Dense(32, 10),
   softmax)
+@show m
 
 # using CuArrays
 # x, y = cu(x), cu(y)
@@ -17,10 +20,19 @@ m = Chain(
 loss(x, y) = mse(m(x), y)
 
 dataset = repeated((x, y), 200)
-evalcb = () -> @show(loss(x, y))
+evalcb = () -> @show(loss(x, y), accuracy(x, y))
+accuracy(x, y) = mean(argmax(m(x), 0:9) .== argmax(y, 0:9))
 opt = SGD(params(m), 0.1)
 
+info("Training")
 Flux.train!(loss, dataset, opt, cb = throttle(evalcb, 5))
 
+info("Training finished")
+@show accuracy(x, y)
+
 # Check the prediction for the first digit
-argmax(m(x[:,1]), 0:9) == argmax(y[:,1], 0:9)
+@assert argmax(m(x[:, 1]), 0:9)[] == argmax(y[:, 1], 0:9)
+
+info("Testing accuracy")
+tx, ty = testdata()
+@show accuracy(tx, onehotbatch(ty, 0:9))


### PR DESCRIPTION
Blocker: https://github.com/FluxML/Flux.jl/pull/83

E.g.
```julia
julia --color=yes --depwarn=no  ./mnist.jl
INFO: Loading train data
INFO: Building model
INFO: Training
loss(x, y) = param(0.0913291)
accuracy(m, x, label, 0.0:9) = 0.10525
loss(x, y) = param(0.0768191)
accuracy(m, x, label, 0.0:9) = 0.31588333333333335
loss(x, y) = param(0.0302687)
accuracy(m, x, label, 0.0:9) = 0.79975
loss(x, y) = param(0.0236859)
accuracy(m, x, label, 0.0:9) = 0.8389666666666666
loss(x, y) = param(0.0223142)
accuracy(m, x, label, 0.0:9) = 0.8474666666666667
loss(x, y) = param(0.0178975)
accuracy(m, x, label, 0.0:9) = 0.87885
loss(x, y) = param(0.0146209)
accuracy(m, x, label, 0.0:9) = 0.9026833333333333
loss(x, y) = param(0.015233)
accuracy(m, x, label, 0.0:9) = 0.8985833333333333
loss(x, y) = param(0.012313)
accuracy(m, x, label, 0.0:9) = 0.9180666666666667
loss(x, y) = param(0.0123472)
accuracy(m, x, label, 0.0:9) = 0.9187166666666666
loss(x, y) = param(0.0111761)
accuracy(m, x, label, 0.0:9) = 0.9269833333333334
loss(x, y) = param(0.0108704)
accuracy(m, x, label, 0.0:9) = 0.9285166666666667
loss(x, y) = param(0.0117668)
accuracy(m, x, label, 0.0:9) = 0.9226333333333333
loss(x, y) = param(0.00992753)
accuracy(m, x, label, 0.0:9) = 0.9350666666666667
loss(x, y) = param(0.00991001)
accuracy(m, x, label, 0.0:9) = 0.9358333333333333
loss(x, y) = param(0.00960475)
accuracy(m, x, label, 0.0:9) = 0.9376666666666666
INFO: Testing accuracy
accuracy(m, tx, ty, 0.0:9) = 0.9393
```