### PR TITLE
VAE Implementation

### DIFF
--- a/mnist/vae.jl
+++ b/mnist/vae.jl
@@ -61,9 +61,9 @@ sample(M::Int=1) = rand.(Bernoulli.(f(z.(zeros(Dz, M), zeros(Dz, M)))))
 
 ################################# Learn Parameters ##############################
 
-evalcb = throttle(() -> @show(-L̄(X[:, rand(1:60000, M)])), 5);
+evalcb = throttle(() -> @show(-L̄(X[:, rand(1:60000, M)])), 30);
 opt = ADAM(vcat(params(A), params(μ), params(logσ), params(f)));
-@progress for i = 1:10
+@progress for i = 1:15
   info("Epoch $i")
-  Flux.train!(X->-L̄(X) + 0.5 * sum(x->sum(x.^2), params(f)), data, opt, cb=evalcb)
+  Flux.train!(X->-L̄(X) + 1e-2 * sum(x->sum(x.^2), params(f)), data, opt, cb=evalcb)
 end

--- a/mnist/vae.jl
+++ b/mnist/vae.jl
@@ -2,8 +2,6 @@ using Flux, Flux.Data.MNIST
 using Flux: throttle, params
 using Juno: @progress
 
-rng = MersenneTwister(1234567)
-
 # Extend distributions slightly to have a numerically stable logpdf for `p` close to 1 or 0.
 using Distributions
 import Distributions: logpdf
@@ -23,7 +21,7 @@ Dz, Dh = 5, 500
 # Components of recognition model / "encoder" MLP.
 A, μ, logσ = Dense(28^2, Dh, tanh), Dense(Dh, Dz), Dense(Dh, Dz)
 g(X) = (h = A(X); (μ(h), logσ(h)))
-z(μ, logσ) = μ + exp(logσ) * randn(rng)
+z(μ, logσ) = μ + exp(logσ) * randn()
 
 # Generative model / "decoder" MLP.
 f = Chain(Dense(Dz, Dh, tanh), Dense(Dh, 28^2, σ))

--- a/mnist/vae.jl
+++ b/mnist/vae.jl
@@ -1,0 +1,72 @@
+using Flux, Flux.Data.MNIST, PyPlot
+using Flux: throttle, params
+using Juno: @progress
+
+struct MinibatchIterator{TX<:AbstractMatrix}
+  X::TX
+  M::Int
+end
+Base.start(d::MinibatchIterator) = 1
+function Base.next(d::MinibatchIterator, p::Int)
+  p′ = min(p + d.M, size(d.X, 2))
+  return (view(d.X, :, p:p′-1),), p′
+end
+Base.done(d::MinibatchIterator, p::Int) = p == size(d.X, 2)
+
+# Extend distributions slightly to have a numerically stable logpdf for `p` close to 1 or 0.
+using Distributions
+import Distributions: logpdf
+logpdf(b::Bernoulli, y::Bool) = y * log(b.p + eps()) + (1 - y) * log(1 - b.p + eps())
+
+# Load data, binarise it, and partition into mini-batches of M.
+X = float(hcat(vec.(MNIST.images())...))
+X[X .> 0.5] = 1
+X[X .< 1] = 0
+X = convert(Matrix{Bool}, X)
+N, M = size(X, 2), 100
+data = MinibatchIterator(X, M)
+
+
+################################# Define Model #################################
+
+# Latent dimensionality, # hidden units, and minibatch sizes resp.
+Dz, Dh = 5, 500
+rng = MersenneTwister(1234567)
+
+# Recognition model / "decoder" MLP.
+g = Dense(28^2, Dh, tanh)
+μ, logσ = Dense(Dh, Dz), Dense(Dh, Dz)
+z(μ, logσ) = μ + exp(logσ) * randn(rng)
+
+# Generative model / "encoder" MLP.
+f = Chain(Dense(Dz, Dh, tanh), Dense(Dh, 28^2, σ))
+
+# Compute ELBO.
+kl(μ, logσ) = 0.5 * sum(exp.(2 .* logσ) + μ.^2 - 1 .+ logσ.^2)
+L̂(X, Xpr) = sum(logpdf.(Bernoulli.(Xpr), X))
+function nveELBO(X)
+  h = g(X)
+  μ̂, logσ̂ = μ(h), logσ(h)
+  ẑ = z.(μ̂, logσ̂)
+  return -(L̂(X, f(ẑ)) - kl(μ̂, logσ̂)) / M
+end
+
+
+################################# Learn Parameters ##############################
+
+evalcb = throttle(() -> @show(nveELBO(X[:, rand(1:60000, M)])), 5)
+opt = ADAM(vcat(params(g), params(μ), params(logσ), params(f)))
+@progress for i = 1:10
+  info("Epoch $i")
+  Flux.train!(nveELBO, data, opt, cb=evalcb)
+end
+
+
+################################# Sample Images #################################
+
+# Sample from the learned model.
+sample(M::Int=1) = rand.(Bernoulli.(f(z.(zeros(Dz, M), zeros(Dz, M)))))
+
+# Get the parameters of the approximate posterior.
+encode(X) = (h = g(X); (μ(h), logσ(h)))
+

--- a/mnist/vae.jl
+++ b/mnist/vae.jl
@@ -63,7 +63,7 @@ sample(M::Int=1) = rand.(Bernoulli.(f(z.(zeros(Dz, M), zeros(Dz, M)))))
 
 evalcb = throttle(() -> @show(-L̄(X[:, rand(1:60000, M)])), 30);
 opt = ADAM(vcat(params(A), params(μ), params(logσ), params(f)));
-@progress for i = 1:15
+@progress for i = 1:20
   info("Epoch $i")
-  Flux.train!(X->-L̄(X) + 0.5 * sum(x->sum(x.^2), params(f)), data, opt, cb=evalcb)
+  Flux.train!(X->-L̄(X) + 0.01 * sum(x->sum(x.^2), params(f)), data, opt, cb=evalcb)
 end

--- a/mnist/vae.jl
+++ b/mnist/vae.jl
@@ -65,5 +65,5 @@ evalcb = throttle(() -> @show(-L̄(X[:, rand(1:60000, M)])), 30);
 opt = ADAM(vcat(params(A), params(μ), params(logσ), params(f)));
 @progress for i = 1:15
   info("Epoch $i")
-  Flux.train!(X->-L̄(X) + 1e-2 * sum(x->sum(x.^2), params(f)), data, opt, cb=evalcb)
+  Flux.train!(X->-L̄(X) + 0.5 * sum(x->sum(x.^2), params(f)), data, opt, cb=evalcb)
 end


### PR DESCRIPTION
(Approximately) reproduces the (binarized) MNIST example in [1]. Uses the same architecture as that proposed in the paper, but uses Adam rather than Adagrad, Xavier init. rather than sampling each parameter's initial value from a Gaussian with zero mean and variance of 0.01, and a broader prior on the model parameters.

I suspect my iterator implementation is unnecessary, so I would appreciate advice here if this is the case.

[1] - Kingma, Diederik P., and Max Welling. "Auto-encoding variational bayes." arXiv preprint arXiv:1312.6114 (2013).