### PR TITLE
Switch autoencoder example to use leakyrelu

### DIFF
--- a/mnist/autoencoder.jl
+++ b/mnist/autoencoder.jl
@@ -20,8 +20,8 @@ N = 32 # Size of the encoding
 # In this case, the input dimension is 28^2 and the output dimension of
 # encoder is 32. This implies that the coding is a compressed representation.
 # We can make lossy compression via this `encoder`.
-encoder = Dense(28^2, N, relu) |> gpu
-decoder = Dense(N, 28^2, relu) |> gpu
+encoder = Dense(28^2, N, leakyrelu) |> gpu
+decoder = Dense(N, 28^2, leakyrelu) |> gpu
 
 m = Chain(encoder, decoder)
 


### PR DESCRIPTION
Using normal relu causes a small portion of the pixels in the reconstructed image to always be black.  It's a bit subtle with normal MNIST but becomes clear with other datasets like F-MNIST.  You can see this effect in the upper-left of the last four images below:

![image](https://user-images.githubusercontent.com/7132414/37867995-61b8af60-2f5d-11e8-890c-16de774ba30d.png)
