### PR TITLE
char-rnn on gpu

### DIFF
--- a/char-rnn/char-rnn.jl
+++ b/char-rnn/char-rnn.jl
@@ -1,4 +1,6 @@
-using CuArrays
+# uncomment to run on gpu, if available
+#using CuArrays
+
 using Flux
 using Flux: onehot, argmax, chunk, batchseq, throttle, logitcrossentropy
 using StatsBase: wsample


### PR DESCRIPTION
Takes 5 minutes on a GPU, vs, 60 minutes on four CPUs. Both train the loss to about 80-85 and produce similar sample output.