### PR TITLE
Changes to CNN to improve model accuracy.

### DIFF
--- a/vision/mnist/conv.jl
+++ b/vision/mnist/conv.jl
@@ -9,9 +9,9 @@ imgs = MNIST.images()
 
 labels = onehotbatch(MNIST.labels(), 0:9)
 
-# Partition into batches of size 1,000
+# Partition into batches of size 32
 train = [(cat(float.(imgs[i])..., dims = 4), labels[:,i])
-         for i in partition(1:60_000, 1000)]
+         for i in partition(1:60_000, 32)]
 
 train = gpu.(train)
 
@@ -20,12 +20,14 @@ tX = cat(float.(MNIST.images(:test)[1:1000])..., dims = 4) |> gpu
 tY = onehotbatch(MNIST.labels(:test)[1:1000], 0:9) |> gpu
 
 m = Chain(
-  Conv((2,2), 1=>16, relu),
-  x -> maxpool(x, (2,2)),
-  Conv((2,2), 16=>8, relu),
-  x -> maxpool(x, (2,2)),
-  x -> reshape(x, :, size(x, 4)),
-  Dense(288, 10), softmax) |> gpu
+    Conv((3, 3), 1=>32, relu),
+    Conv((3, 3), 32=>32, relu),
+    x -> maxpool(x, (2,2)),
+    Conv((3, 3), 32=>16, relu),
+    x -> maxpool(x, (2,2)),
+    Conv((3, 3), 16=>10, relu),
+    x -> reshape(x, :, size(x, 4)),
+    Dense(90, 10), softmax) |> gpu
 
 m(train[1][1])
 


### PR DESCRIPTION
Improved the CNN accuracy for model zoo. The batch size has been reduced to 32 instead of 1000 which improves accuracy of training significantly. 

```
julia> include("conv.jl")
accuracy(tX, tY) = 0.11
accuracy(tX, tY) = 0.248
accuracy(tX, tY) = 0.736
accuracy(tX, tY) = 0.804
accuracy(tX, tY) = 0.799
accuracy(tX, tY) = 0.842
accuracy(tX, tY) = 0.882
accuracy(tX, tY) = 0.876
accuracy(tX, tY) = 0.898
accuracy(tX, tY) = 0.91
accuracy(tX, tY) = 0.901
accuracy(tX, tY) = 0.918
accuracy(tX, tY) = 0.926
accuracy(tX, tY) = 0.932
accuracy(tX, tY) = 0.925
accuracy(tX, tY) = 0.929
accuracy(tX, tY) = 0.928
accuracy(tX, tY) = 0.941
accuracy(tX, tY) = 0.942
accuracy(tX, tY) = 0.947
accuracy(tX, tY) = 0.938
accuracy(tX, tY) = 0.94
accuracy(tX, tY) = 0.929
accuracy(tX, tY) = 0.945
accuracy(tX, tY) = 0.949
accuracy(tX, tY) = 0.952
accuracy(tX, tY) = 0.945
accuracy(tX, tY) = 0.937
accuracy(tX, tY) = 0.947
accuracy(tX, tY) = 0.948
accuracy(tX, tY) = 0.943
accuracy(tX, tY) = 0.952
accuracy(tX, tY) = 0.946
accuracy(tX, tY) = 0.96
accuracy(tX, tY) = 0.961
accuracy(tX, tY) = 0.928
accuracy(tX, tY) = 0.965
accuracy(tX, tY) = 0.955
```

The original output:
```
julia> include("conv.jl")
accuracy(tX, tY) = 0.126
accuracy(tX, tY) = 0.126
accuracy(tX, tY) = 0.126
accuracy(tX, tY) = 0.157
accuracy(tX, tY) = 0.52
```

There is definite gains in using the modified code. 