### PR TITLE
adding epochs to conv mnist classifier

### DIFF
--- a/vision/mnist/conv.jl
+++ b/vision/mnist/conv.jl
@@ -1,5 +1,5 @@
 using Flux, Flux.Data.MNIST, Statistics
-using Flux: onehotbatch, onecold, crossentropy, throttle
+using Flux: onehotbatch, onecold, crossentropy, throttle, @epochs
 using Base.Iterators: repeated, partition
 # using CuArrays
 
@@ -36,4 +36,6 @@ accuracy(x, y) = mean(onecold(m(x)) .== onecold(y))
 evalcb = throttle(() -> @show(accuracy(tX, tY)), 10)
 opt = ADAM(params(m))
 
-Flux.train!(loss, train, opt, cb = evalcb)
+@epochs 10 Flux.train!(loss, train, opt, cb = evalcb)
+
+accuracy(tX, tY)


### PR DESCRIPTION
As discussed on slack, the conv mnist classifier only trained for one epoch. This PR corrects that.

The mlp classifier also only trains for one epoch, but simulates 200 epochs

```
dataset = repeated((X, Y), 200)
evalcb = () -> @show(loss(X, Y))
opt = ADAM(params(m))

Flux.train!(loss, dataset, opt, cb = throttle(evalcb, 10))
```
Should this also be fixed to promote best practices?

This is my first PR here, so any advice is greatly appreciated.