### PR TITLE
Fixes to CIFAR10 Model

### DIFF
--- a/vision/cifar10/cifar10.jl
+++ b/vision/cifar10/cifar10.jl
@@ -1,6 +1,8 @@
 using Flux, Metalhead
 using Flux: onehotbatch, onecold, crossentropy, throttle
 using Metalhead: trainimgs
+using Images: channelview
+using Statistics: mean
 using Base.Iterators: partition
 
 # VGG16 and VGG19 models
@@ -90,16 +92,16 @@ vgg19() = Chain(
 
 # Function to convert the RGB image to Float64 Arrays
 
-getarray(X) = float.(permutedims(channelview(im), (2, 3, 1)))
+getarray(X) = Float64.(permutedims(channelview(X), (2, 3, 1)))
 
 # Fetching the train and validation data and getting them into proper shape
 
 X = trainimgs(CIFAR10)
 imgs = [getarray(X[i].img) for i in 1:50000]
 labels = onehotbatch([X[i].ground_truth.class for i in 1:50000],1:10)
-train = gpu.([(cat(4, imgs[i]...), labels[:,i]) for i in partition(1:49000, 1000)])
+train = gpu.([(cat(imgs[i]..., dims=4), labels[:,i]) for i in partition(1:49000, 1000)])
 valset = collect(49001:50000)
-valX = cat(4, imgs[valset]...) |> gpu
+valX = cat(imgs[valset]..., dims=4) |> gpu
 valY = labels[:, valset] |> gpu
 
 # Defining the loss and accuracy functions
@@ -127,7 +129,7 @@ test = valimgs(CIFAR10)
 
 testimgs = [getarray(test[i].img) for i in 1:10000]
 testY = onehotbatch([test[i].ground_truth.class for i in 1:10000], 1:10) |> gpu
-testX = cat(4, testimgs...) |> gpu
+testX = cat(testimgs..., dims=4) |> gpu
 
 # Print the final accuracy
 


### PR DESCRIPTION
Force getarray to return CIFAR images as Float64, using float method returns Float32.

cat takes dims as a keyword arg.