### PR TITLE
Fix x type to match m

### DIFF
--- a/tutorials/60-minute-blitz.jl
+++ b/tutorials/60-minute-blitz.jl
@@ -196,7 +196,7 @@ using Flux
 
 m = Dense(10, 5)
 
-x = rand(10)
+x = rand(Float32, 10)
 
 m(x)
 #-


### PR DESCRIPTION
Changing `x` type from default `Float64` to `Float32`, to match `Dense` on comparison:

```julia
m = Dense(10, 5)

x = rand(Float32, 10)

m(x)
#-
m(x) == m.W * x .+ m.b
```