### PR TITLE
Fix GPU support for cifar10, MNIST mlp, and MNIST conv examples

### DIFF
--- a/vision/cifar10/cifar10.jl
+++ b/vision/cifar10/cifar10.jl
@@ -4,6 +4,7 @@ using Metalhead: trainimgs
 using Images: channelview
 using Statistics: mean
 using Base.Iterators: partition
+# using CuArrays
 
 # VGG16 and VGG19 models
 
@@ -110,7 +111,7 @@ m = vgg16()
 
 loss(x, y) = crossentropy(m(x), y)
 
-accuracy(x, y) = mean(onecold(m(x), 1:10) .== onecold(y, 1:10))
+accuracy(x, y) = mean(onecold(m(x), 1:10) |> gpu .== onecold(y, 1:10) |> gpu)
 
 # Defining the callback and the optimizer
 

--- a/vision/mnist/conv.jl
+++ b/vision/mnist/conv.jl
@@ -10,7 +10,7 @@ using Flux, Flux.Data.MNIST, Statistics
 using Flux: onehotbatch, onecold, crossentropy, throttle
 using Base.Iterators: repeated, partition
 using Printf, BSON
-using CuArrays
+# using CuArrays
 
 # Load labels and images from Flux.Data.MNIST
 @info("Loading data set")

--- a/vision/mnist/conv.jl
+++ b/vision/mnist/conv.jl
@@ -10,6 +10,7 @@ using Flux, Flux.Data.MNIST, Statistics
 using Flux: onehotbatch, onecold, crossentropy, throttle
 using Base.Iterators: repeated, partition
 using Printf, BSON
+using CuArrays
 
 # Load labels and images from Flux.Data.MNIST
 @info("Loading data set")
@@ -78,7 +79,7 @@ function loss(x, y)
     y_hat = model(x_aug)
     return crossentropy(y_hat, y)
 end
-accuracy(x, y) = mean(onecold(model(x)) .== onecold(y))
+accuracy(x, y) = mean(onecold(model(x)) |> gpu .== onecold(y) |> gpu)
 
 # Train our model with the given training set using the ADAM optimizer and
 # printing out performance against the test set as we go.
@@ -95,7 +96,7 @@ for epoch_idx in 1:100
     # Calculate accuracy:
     acc = accuracy(test_set...)
     @info(@sprintf("[%d]: Test accuracy: %.4f", epoch_idx, acc))
-    
+
     # If our accuracy is good enough, quit out.
     if acc >= 0.999
         @info(" -> Early-exiting: We reached our target accuracy of 99.9%")

--- a/vision/mnist/mlp.jl
+++ b/vision/mnist/mlp.jl
@@ -1,7 +1,7 @@
 using Flux, Flux.Data.MNIST, Statistics
 using Flux: onehotbatch, onecold, crossentropy, throttle
 using Base.Iterators: repeated
-# using CuArrays
+using CuArrays
 
 # Classify MNIST digits with a simple multi-layer-perceptron
 
@@ -20,7 +20,7 @@ m = Chain(
 
 loss(x, y) = crossentropy(m(x), y)
 
-accuracy(x, y) = mean(onecold(m(x)) .== onecold(y))
+accuracy(x, y) = mean(onecold(m(x)) |> gpu .== onecold(y) |> gpu)
 
 dataset = repeated((X, Y), 200)
 evalcb = () -> @show(loss(X, Y))

--- a/vision/mnist/mlp.jl
+++ b/vision/mnist/mlp.jl
@@ -1,7 +1,7 @@
 using Flux, Flux.Data.MNIST, Statistics
 using Flux: onehotbatch, onecold, crossentropy, throttle
 using Base.Iterators: repeated
-using CuArrays
+# using CuArrays
 
 # Classify MNIST digits with a simple multi-layer-perceptron
 


### PR DESCRIPTION
This PR addresses the following two issues
https://github.com/FluxML/model-zoo/issues/102
https://github.com/FluxML/model-zoo/issues/125

Simple fix for the accuracy function that currently fails when CuArrays is enabled.

Just need to send the onecold()'s to the gpu

```
accuracy(x, y) = mean(onecold(m(x)) |> gpu .== onecold(y) |> gpu)
```

