### PR TITLE
Do not let Float64 creep into the loss function

### DIFF
--- a/vision/mnist/conv.jl
+++ b/vision/mnist/conv.jl
@@ -73,7 +73,7 @@ model(train_set[1][1])
 # a bit, adding gaussian random noise to our image to make it more robust.
 function loss(x, y)
     # We augment `x` a little bit here, adding in random noise
-    x_aug = x .+ 0.1*gpu(randn(eltype(x), size(x)))
+    x_aug = x .+ 0.1f0*gpu(randn(eltype(x), size(x)))
 
     y_hat = model(x_aug)
     return crossentropy(y_hat, y)


### PR DESCRIPTION
This change fixes an error I got and which seems to be due to the multiplication with 0.1 (Float64) converting the array to Array{Float64}