### PR TITLE
Use the more idiomatic MaxPool((2,2))

### DIFF
--- a/vision/mnist/conv.jl
+++ b/vision/mnist/conv.jl
@@ -41,15 +41,15 @@ test_set = make_minibatch(test_imgs, test_labels, 1:length(test_imgs))
 model = Chain(
     # First convolution, operating upon a 28x28 image
     Conv((3, 3), 1=>16, pad=(1,1), relu),
-    x -> maxpool(x, (2,2)),
+    MaxPool((2,2)),
 
     # Second convolution, operating upon a 14x14 image
     Conv((3, 3), 16=>32, pad=(1,1), relu),
-    x -> maxpool(x, (2,2)),
+    MaxPool((2,2)),
 
     # Third convolution, operating upon a 7x7 image
     Conv((3, 3), 32=>32, pad=(1,1), relu),
-    x -> maxpool(x, (2,2)),
+    MaxPool((2,2)),
 
     # Reshape 3d tensor into a 2d one, at this point it should be (3, 3, 32, N)
     # which is where we get the 288 in the `Dense` layer below:


### PR DESCRIPTION
instead of x -> maxpool(x, (2,2)). Looks a bit cleaner, too..