### PR TITLE
Another mistake in KL-divergence equation vae.jl

### DIFF
--- a/vision/mnist/vae.jl
+++ b/vision/mnist/vae.jl
@@ -30,7 +30,7 @@ f = Chain(Dense(Dz, Dh, tanh), Dense(Dh, 28^2, σ))
 ####################### Define ways of doing things with the model. #######################
 
 # KL-divergence between approximation posterior and N(0, 1) prior.
-kl_q_p(μ, logσ) = 0.5f0 * sum(exp.(2f0 .* logσ) + μ.^2 .- 1f0 .+ logσ.^2)
+kl_q_p(μ, logσ) = 0.5f0 * sum(exp.(2f0 .* logσ) + μ.^2 .- 1f0 .-  (2 .* logσ))
 
 # logp(x|z) - conditional probability of data given latents.
 logp_x_z(x, z) = sum(logpdf.(Bernoulli.(f(z)), x))

--- a/vision/mnist/vae.jl
+++ b/vision/mnist/vae.jl
@@ -30,7 +30,7 @@ f = Chain(Dense(Dz, Dh, tanh), Dense(Dh, 28^2, σ))
 ####################### Define ways of doing things with the model. #######################
 
 # KL-divergence between approximation posterior and N(0, 1) prior.
-kl_q_p(μ, logσ) = 0.5f0 * sum(exp.(2f0 .* logσ) + μ.^2 .- 1f0 .-  (2 .* logσ))
+kl_q_p(μ, logσ) = 0.5f0 * sum(exp.(2f0 .* logσ) + μ.^2 .- 1f0 .- (2 .* logσ))
 
 # logp(x|z) - conditional probability of data given latents.
 logp_x_z(x, z) = sum(logpdf.(Bernoulli.(f(z)), x))


### PR DESCRIPTION
As mentioned by @AbinavRavi in KL-divergence equation we should have 2*logσ instead of logσ.^2 but the other mistake is the sign of this which should be -2*logσ 