### PR TITLE
Add gitpod config

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,5 @@
+image: julia
+
+vscode:
+  extensions:
+    - julialang.language-julia@0.12.3:lgRyBd8rjwUpMGG0C5GAig==

--- a/README.md
+++ b/README.md
@@ -21,6 +21,16 @@ using Pkg; Pkg.activate("cuda"); Pkg.instantiate()
 using CuArrays
 ```
 
+### Gitpod Online IDE
+
+Each model can be used in [Gitpod](https://www.gitpod.io/), just [open the repository by gitpod](https://gitpod.io/#https://github.com/FluxML/model-zoo)
+
+#### Consideration:
+
+* Based on [Gitpod's policies](https://www.gitpod.io/pricing/), free access is limited.
+* All of your work will place in the Gitpod's cloud.
+* It isn't an officially maintained feature.
+
 ## Contributing
 
 We welcome contributions of new models. They should be in a folder with a project and manifest file, to pin all relevant packages, as well as a README to explain what the model is about, how to run it, and what results it achieves (if applicable). If possible models should not depend directly on GPU functionality, but ideally should be CPU/GPU agnostic.


### PR DESCRIPTION
I just add a simple [gitpod](https://www.gitpod.io/) config.
When someone open this repository by gitpod, it should install julia language first and optionally julia extension, so I just add julia docker image and julia vscode extension to the repository's gitpod config and now everyone can develop or run models in gitpod for free. :smile: 