### PR TITLE
Added note for usage of common datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Models with a `cuda` folder can be loaded with NVIDIA GPU support, if you have a
 using Pkg; Pkg.activate("cuda"); Pkg.instantiate()
 using CuArrays
 ```
-Note: Place your downloaded dataset where MetalHead is installed, typically in `/home/<user>/.julia/packages/MetalHead/fYeSU/src/datasets`
+**Note**: For working with common datasets, refer <a href = https://github.com/FluxML/Metalhead.jl#working-with-common-datasets> here </a>
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Models with a `cuda` folder can be loaded with NVIDIA GPU support, if you have a
 using Pkg; Pkg.activate("cuda"); Pkg.instantiate()
 using CuArrays
 ```
-**Note**: For working with common datasets, refer <a href = https://github.com/FluxML/Metalhead.jl#working-with-common-datasets> here </a>
+**Note**: For working with common datasets, refer [here](https://github.com/FluxML/Metalhead.jl#working-with-common-datasets>)
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Models with a `cuda` folder can be loaded with NVIDIA GPU support, if you have a
 using Pkg; Pkg.activate("cuda"); Pkg.instantiate()
 using CuArrays
 ```
+Note: Place your downloaded dataset where MetalHead is installed, typically in `/home/<user>/.julia/packages/MetalHead/fYeSU/src/datasets`
 
 ## Contributing
 


### PR DESCRIPTION
The path to place the datasets for use with MetalHead is not clear. This PR aims to add a note entry in `README.md` to specify where to place the datasets. Useful for first time users 