### PR TITLE
Changed to zygote

### DIFF
--- a/audio/speech-blstm/00-data.jl
+++ b/audio/speech-blstm/00-data.jl
@@ -3,7 +3,7 @@
 
 using Flux
 using Flux: onehotbatch
-using Flux.Zygote: @nograd
+using Zygote: @nograd
 using WAV
 using BSON
 

--- a/other/bitstring-parity/data.jl
+++ b/other/bitstring-parity/data.jl
@@ -1,5 +1,5 @@
 using Flux: onehot, onehotbatch
-using Flux.Zygote: @nograd
+using Zygote: @nograd
 using Random
 
 @nograd Flux.reset!

--- a/text/char-rnn/char-rnn.jl
+++ b/text/char-rnn/char-rnn.jl
@@ -2,7 +2,7 @@ using Flux
 using Flux: onehot, chunk, batchseq, throttle, crossentropy
 using StatsBase: wsample
 using Base.Iterators: partition
-using Flux.Zygote: @nograd
+using Zygote: @nograd
 
 cd(@__DIR__)
 

--- a/text/lang-detection/model.jl
+++ b/text/lang-detection/model.jl
@@ -2,7 +2,7 @@ using Flux
 using Flux: onehot, onehotbatch, crossentropy, reset!, throttle
 using Unicode: normalize
 using Random: shuffle
-using Flux.Zygote: @nograd
+using Zygote: @nograd
 using Statistics
 
 @nograd Flux.reset!

--- a/text/phonemes/1-model.jl
+++ b/text/phonemes/1-model.jl
@@ -1,7 +1,7 @@
 # Based on https://arxiv.org/abs/1409.0473
 
 using Flux: flip, crossentropy, reset!, throttle
-using Flux.Zygote: @nograd
+using Zygote: @nograd
 
 @nograd reset!
 @nograd flip

--- a/tutorials/60-minute-blitz.jl
+++ b/tutorials/60-minute-blitz.jl
@@ -279,7 +279,7 @@ Flux.train!(loss, params(m), [(data,labels)], opt)
 
 using Statistics
 # using CuArrays
-using Flux, Flux.Zygote, Flux.Optimise
+using Flux, Zygote, Flux.Optimise
 using Metalhead, Images
 using Metalhead: trainimgs
 using Images.ImageCore

--- a/vision/mnist/conv.jl
+++ b/vision/mnist/conv.jl
@@ -10,7 +10,7 @@ using Flux, Flux.Data.MNIST, Statistics
 using Flux: onehotbatch, onecold, crossentropy, throttle
 using Base.Iterators: repeated, partition
 using Printf, BSON
-using Flux.Zygote: @nograd
+using Zygote: @nograd
 
 @nograd gpu
 


### PR DESCRIPTION
These files had `Flux.Zygote` as import mechanism, which caused `Unknown variable Zygote` error. This PR fixes that by changing to `Using Zygote`