### PR TITLE
change `truncate!` to `reset!` in char-rnn

### DIFF
--- a/text/char-rnn/char-rnn.jl
+++ b/text/char-rnn/char-rnn.jl
@@ -31,7 +31,7 @@ m = gpu(m)
 
 function loss(xs, ys)
   l = sum(crossentropy.(m.(gpu.(xs)), gpu.(ys)))
-  Flux.truncate!(m)
+  Flux.reset!(m)
   return l
 end
 


### PR DESCRIPTION
The method `truncate!` is no longer used and `reset!` is now preferred. Changing it so that this example runs without errors.