### PR TITLE
Changed dependency from CuArrays to CUDA

### DIFF
--- a/vision/cdcgan_mnist/cGAN_mnist.jl
+++ b/vision/cdcgan_mnist/cGAN_mnist.jl
@@ -12,8 +12,8 @@ using CUDAapi
 using Zygote
 if has_cuda()		# Check if CUDA is available
     @info "CUDA is on"
-    import CuArrays		# If CUDA is available, import CuArrays
-    CuArrays.allowscalar(false)
+    import CUDA		# If CUDA is available, import CUDA
+    CUDA.allowscalar(false)
 end
 
 @with_kw struct HyperParams

--- a/vision/cifar10/cifar10.jl
+++ b/vision/cifar10/cifar10.jl
@@ -8,8 +8,8 @@ using Base.Iterators: partition
 using CUDAapi
 if has_cuda()
     @info "CUDA is on"
-    import CuArrays
-    CuArrays.allowscalar(false)
+    import CUDA
+    CUDA.allowscalar(false)
 end
 
 @with_kw mutable struct Args

--- a/vision/mnist/autoencoder.jl
+++ b/vision/mnist/autoencoder.jl
@@ -7,8 +7,8 @@ using Parameters: @with_kw
 using CUDAapi
 if has_cuda()
     @info "CUDA is on"
-    import CuArrays
-    CuArrays.allowscalar(false)
+    import CUDA
+    CUDA.allowscalar(false)
 end
 
 @with_kw mutable struct Args

--- a/vision/mnist/conv.jl
+++ b/vision/mnist/conv.jl
@@ -14,8 +14,8 @@ using Parameters: @with_kw
 using CUDAapi
 if has_cuda()
     @info "CUDA is on"
-    import CuArrays
-    CuArrays.allowscalar(false)
+    import CUDA
+    CUDA.allowscalar(false)
 end
 
 @with_kw mutable struct Args

--- a/vision/mnist/mlp.jl
+++ b/vision/mnist/mlp.jl
@@ -7,8 +7,8 @@ using CUDAapi
 using MLDatasets
 if has_cuda()		# Check if CUDA is available
     @info "CUDA is on"
-    import CuArrays		# If CUDA is available, import CuArrays
-    CuArrays.allowscalar(false)
+    import CUDA		# If CUDA is available, import CuArrays
+    CUDA.allowscalar(false)
 end
 
 @with_kw mutable struct Args

--- a/vision/mnist/mlp.jl
+++ b/vision/mnist/mlp.jl
@@ -7,7 +7,7 @@ using CUDAapi
 using MLDatasets
 if has_cuda()		# Check if CUDA is available
     @info "CUDA is on"
-    import CUDA		# If CUDA is available, import CuArrays
+    import CUDA		# If CUDA is available, import CUDA
     CUDA.allowscalar(false)
 end
 


### PR DESCRIPTION
[CuArrays.jl is deprecated](https://github.com/JuliaGPU/CuArrays.jl#cuarraysjl-deprecated-use-cudajl-instead) and is replaced by CUDA.jl. Changing `CuArrays` to `CUDA` fixes errors related to this.