### PR TITLE
Avoid repeating download

### DIFF
--- a/vision/mnist/mlp.jl
+++ b/vision/mnist/mlp.jl
@@ -18,7 +18,7 @@ end
 end
 
 function getdata(args)
-    MLDatasets.MNIST.download(i_accept_the_terms_of_use=true)
+    ENV["DATADEPS_ALWAYS_ACCEPT"] = "true"
 
     # Loading Dataset	
     xtrain, ytrain = MLDatasets.MNIST.traindata(Float32)


### PR DESCRIPTION
In example of [MNIST mlp](https://github.com/FluxML/model-zoo/blob/0e8de61cf466868b13a629e9a9275cfe7eafa6c6/vision/mnist/mlp.jl#L21),
original data is always downloaded even if it is already in the local machine.

This pull request fixes this issue while bypassing the confirmation under the guidance [here](https://www.oxinabox.net/DataDeps.jl/stable/z10-for-end-users/#Configuration-1).
