### PR TITLE
Fix NaNs in some cases for transfer learning tutorial

### DIFF
--- a/tutorials/transfer_learning/transfer_learning.jl
+++ b/tutorials/transfer_learning/transfer_learning.jl
@@ -52,7 +52,6 @@ model = Chain(
   Dense(2048, 1000),  
   Dense(1000, 256),
   Dense(256, 2),        # we get 2048 features out, and we have 2 classes
-  softmax
 )
 
 # To speed up training, let’s move everything over to the GPU
@@ -63,7 +62,7 @@ dataset = [gpu.(load_batch(10)) for i in 1:10]
 # After this, we only need to define the other parts of the training pipeline like we usually do.
 
 opt = ADAM()
-loss(x,y) = Flux.Losses.crossentropy(model(x), y)
+loss(x,y) = Flux.Losses.logitcrossentropy(model(x), y)
 
 # Now to train
 # As discussed earlier, we don’t need to pass all the parameters to our training loop. Only the ones we need to


### PR DESCRIPTION
The transfer learning tutorial sometimes returns NaNs (see https://github.com/FluxML/model-zoo/issues/242). Removing the softmax layer and training with a logitcrossentropy loss seem to solve these cases.