### PR TITLE
fix grey image output in vae_mnist

### DIFF
--- a/vision/vae_mnist/vae_plot.jl
+++ b/vision/vae_mnist/vae_plot.jl
@@ -31,6 +31,7 @@ function plot_result()
     x[1, :] = z1
     x[2, :] = z2
     samples = decoder(x)
+    samples = sigmoid.(samples)
     image = convert_to_image(samples, len)
     save("output/manifold.png", image)
 end


### PR DESCRIPTION
In vae_plot.jl the sigmoid needs to be applied to the sampled output from the decoder. Otherwise, the generated image `output/manifold.png` is corrupted.

The error was caused by the commits in FluxML#267 that removed the sigmoid from the last decoder layer to enable the use of the more numerically stable logitbinarycrossentropy loss. However, only the output in [vae_mnist.jl](https://github.com/FluxML/model-zoo/blob/7436c5c7457fd5aaa5ddeec09f506fec42d43639/vision/vae_mnist/vae_mnist.jl#L160) was adapted. The output in `vae_plot.jl` was not adapted.