### PR TITLE
fix use of decays

### DIFF
--- a/contrib/games/differentiable-programming/cartpole/DQN.jl
+++ b/contrib/games/differentiable-programming/cartpole/DQN.jl
@@ -35,7 +35,7 @@ model = Chain(Dense(STATE_SIZE, 24, tanh),
 
 loss(x, y) = Flux.mse(model(x), y)
 
-opt = Flux.Optimiser(ADAM(η), InvDecay(η_decay))
+opt = Flux.Optimiser(InvDecay(η_decay), ADAM(η))
 
 # ----------------------------- Helper Functions -------------------------------
 

--- a/vision/conv_mnist/conv_mnist.jl
+++ b/vision/conv_mnist/conv_mnist.jl
@@ -107,7 +107,7 @@ function train(; kws...)
 
     opt = ADAM(args.η) 
     if args.λ > 0 # add weight decay, equivalent to L2 regularization
-        opt = Optimiser(opt, WeightDecay(args.λ))
+        opt = Optimiser(WeightDecay(args.λ), opt)
     end
     
     ## LOGGING UTILITIES


### PR DESCRIPTION
`WeightDecay` and similia should always be applied before the actual optimizer, otherwise their contribution to the gradient won't be multiplied by the learning rate.

cc @carlobaldassi