### PR TITLE
revert InvDecay swap

### DIFF
--- a/contrib/games/differentiable-programming/cartpole/DQN.jl
+++ b/contrib/games/differentiable-programming/cartpole/DQN.jl
@@ -35,7 +35,7 @@ model = Chain(Dense(STATE_SIZE, 24, tanh),
 
 loss(x, y) = Flux.mse(model(x), y)
 
-opt = Flux.Optimiser(InvDecay(η_decay), ADAM(η))
+opt = Flux.Optimiser(ADAM(η), InvDecay(η_decay))
 
 # ----------------------------- Helper Functions -------------------------------
 


### PR DESCRIPTION
Revert part of the change in #303 since applying InvDecay as last makes more sense (at odds with WeightDecays that has to be always first). This way InvDecay acts as a learning rate scheduler.