### PR TITLE
Fix error when running char-rnn.jl

### DIFF
--- a/text/char-rnn/char-rnn.jl
+++ b/text/char-rnn/char-rnn.jl
@@ -72,7 +72,7 @@ function train(; kws...)
 end
 
 # Sampling
-function sample(m, alphabet, len; seed="")
+function sample_data(m, alphabet, len; seed="")
     m = cpu(m)
     Flux.reset!(m)
     buf = IOBuffer()
@@ -90,4 +90,4 @@ end
 
 cd(@__DIR__)
 m, alphabet = train()
-sample(m, alphabet, 1000) |> println
+sample_data(m, alphabet, 1000) |> println


### PR DESCRIPTION
Right now, I get the following when trying to run char-rnn.jl: 

```Julia
ERROR: LoadError: error in method definition: function StatsBase.sample must be explicitly imported to be extended
Stacktrace:
 [1] top-level scope
```

Updating the function name resolves this issue.