### PR TITLE
Link to MLJFlux examples?

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ To run the old examples, Flux v0.11 can be installed and run on [Julia 1.6, the 
 Flux v0.12 works on Julia 1.8.
 Flux 0.13 is the latest right now, marked with ☀️.
 
-## Examples Listing
+## Examples in the Model Zoo
 
 **Vision**
 * MNIST
@@ -96,3 +96,10 @@ Flux 0.13 is the latest right now, marked with ☀️.
 * [DataLoader example with image data](tutorials/dataloader) ⛅️ v0.11
 * [Transfer Learning](tutorials/transfer_learning/transfer_learning.jl) ⛅️ v0.11
 
+## Examples Elsewhere
+
+**MLJFlux** is a bridge to [MLJ.jl](https://github.com/alan-turing-institute/MLJ.jl), a package for mostly non-neural-network machine learning. They have some examples of interest, which like the model zoo's examples, each include a local Project & Manifest file:
+
+* [Iris](https://github.com/FluxML/MLJFlux.jl/tree/dev/examples/iris) ⛅️ v0.11
+* [Boston](https://github.com/FluxML/MLJFlux.jl/tree/dev/examples/boston) ⛅️ v0.11
+* [MNIST](https://github.com/FluxML/MLJFlux.jl/tree/dev/examples/mnist) ⛅️ v0.11


### PR DESCRIPTION
Should this package's readme list examples which aren't hosted here, which might be of interest? Seems like a somewhat natural place to look. 

This thread points to MLJFlux:

https://discourse.julialang.org/t/flux-categorical-arrays-roc-curves-confusion-matrices/91282/10