### PR TITLE
Update char-rnn.jl for `v0.13.9` and some improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Flux v0.13 is the latest right now, marked with ☀️; models upgraded to use  
   * [ConvMixer "Patches are all you need?"](vision/convmixer_cifar10/) ☀️ v0.13
 
 **Text**
-* [CharRNN](text/char-rnn) ⛅️ v0.11
+* [CharRNN](text/char-rnn) ☀️ v0.13.9
 * [Character-level language detection](text/lang-detection) ⛅️ v0.11
 * [Seq2Seq phoneme detection on CMUDict](text/phonemes) ⛅️ v0.11
 * [Recursive net on IMDB sentiment treebank](text/treebank) ⛅️ v0.11

--- a/text/char-rnn/Project.toml
+++ b/text/char-rnn/Project.toml
@@ -4,5 +4,5 @@ Parameters = "d96e819e-fc66-5662-9728-84c9c7592b0a"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
-Flux = "0.11.4"
-julia = "1.5"
+Flux = "0.13.9"
+julia = "1.6"

--- a/text/char-rnn/README.md
+++ b/text/char-rnn/README.md
@@ -1,12 +1,12 @@
-# RNN Character level
+# Character-Level RNN
 
 ![char-rnn](../char-rnn/docs/rnn-train.png)
 
 [Source](https://d2l.ai/chapter_recurrent-neural-networks/rnn.html#rnn-based-character-level-language-models)
 
-## Model information
+## Model Information
 
- A recurrent neural network (RNN) outputs a prediction and a hidden state at each step of the computation. The hidden state captures historical information of a sequence (i.e. the neural network has memory) and the output is the final prediction of the model. We use this type of neural network to model sequences such as text or time series. 
+ A recurrent neural network (RNN) outputs a prediction and a hidden state at each step of the computation. The hidden state captures historical information of a sequence (i.e., the neural network has memory) and the output is the final prediction of the model. We use this type of neural network to model sequences such as text or time series.
 
 
 ## Training

--- a/text/char-rnn/char-rnn.jl
+++ b/text/char-rnn/char-rnn.jl
@@ -60,11 +60,6 @@ function getdata(args)
 
     ## an array of all unique characters
     alphabet = [unique(text)..., '_']
-
-    
-    # text = map(ch -> onehot(ch, alphabet), text)
-    # println(typeof(text))
-    # stop = onehot('_', alphabet)
     stop = '_'
 
     N = length(alphabet)

--- a/text/char-rnn/char-rnn.jl
+++ b/text/char-rnn/char-rnn.jl
@@ -3,8 +3,8 @@
 # In this example, we create a character-level recurrent neural network. 
 # A recurrent neural network (RNN) outputs a prediction and a hidden state at each step 
 # of the computation. The hidden state captures historical information of a sequence 
-# (i.e. the neural network has memory) and the output is the final prediction of the model. 
-# We use this type of neural network to model sequences such as text or time series. 
+# (i.e., the neural network has memory) and the output is the final prediction of the model.
+# We use this type of neural network to model sequences such as text or time series.
 
 
 # ![char-rnn](../char-rnn/docs/rnn-train.png)
@@ -38,9 +38,9 @@ using Random: shuffle
     lr::Float64 = 1e-2	       # Learning rate
     seqlen::Int = 50	       # Length of batch sequences
     batchsz::Int = 50	       # Number of sequences in each batch
-    epochs::Int = 3            # Number of Epochs
-    usegpu::Bool = true        # Whether or not to use the GPU
-    testpercent::Float64 = .05 # percent of corpus examples to use for testing
+    epochs::Int = 3            # Number of epochs
+    usegpu::Bool = false       # Whether or not to use the GPU
+    testpercent::Float64 = .05 # Percent of corpus examples to use for testing
 end
 
 # ## Data


### PR DESCRIPTION
This resolves #379. The `char-rnn.jl` example was broken after Flux `v0.13.9` due to a data format issue.

This PR does a few things:
- fixes #379 
- adds gpu support
- adds better train/test split
- simplifies data preparation
- adds averaged loss metric
- minor formatting changes
- removes callback (in favor of per-epoch loss report)
