### PR TITLE
Allow Flux 0.14 everywhere 0.13 was used

### DIFF
--- a/other/autoregressive-process/Project.toml
+++ b/other/autoregressive-process/Project.toml
@@ -4,5 +4,5 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
-Flux = "0.13.9"
+Flux = "0.13.9, 0.14"
 julia = "1.6"

--- a/other/fizzbuzz/Project.toml
+++ b/other/fizzbuzz/Project.toml
@@ -3,5 +3,5 @@ Flux = "587475ba-b771-5e3f-ad9e-33799f191a9c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-Flux = "0.13.9"
+Flux = "0.13.9, 0.14"
 julia = "1.6"

--- a/other/iris/Project.toml
+++ b/other/iris/Project.toml
@@ -6,6 +6,6 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
 DataFrames = "1.4.3"
-Flux = "0.13.9"
+Flux = "0.13.9, 0.14"
 MLDatasets = "0.7.6"
 julia = "1.6"

--- a/text/char-rnn/Project.toml
+++ b/text/char-rnn/Project.toml
@@ -4,5 +4,5 @@ OneHotArrays = "0b1bfda6-eb8a-41d2-88d8-f5af5cad476f"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
-Flux = "0.13.9"
+Flux = "0.13.9, 0.14"
 julia = "1.6"

--- a/text/lang-detection/Project.toml
+++ b/text/lang-detection/Project.toml
@@ -9,7 +9,7 @@ Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 
 [compat]
 Cascadia = "1"
-Flux = "0.13.9"
+Flux = "0.13.9, 0.14"
 Gumbo = "0.8"
 HTTP = "1.7"
 julia = "1.6"

--- a/tutorials/transfer_learning/Project.toml
+++ b/tutorials/transfer_learning/Project.toml
@@ -7,5 +7,5 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
-Flux = "0.13"
+Flux = "0.13, 0.14"
 julia = "1.6"

--- a/tutorials/transfer_learning/transfer_learning.jl
+++ b/tutorials/transfer_learning/transfer_learning.jl
@@ -2,12 +2,12 @@
 using Random: shuffle!
 import Base: length, getindex
 using Images
-using Flux
+using Flux, CUDA
 using Flux: update!
 using DataAugmentation
 using Metalhead
 
-device = Flux.CUDA.functional() ? gpu : cpu
+device = CUDA.functional() ? gpu : cpu
 # device = cpu
 
 ## Custom DataLoader

--- a/vision/dcgan_mnist/Project.toml
+++ b/vision/dcgan_mnist/Project.toml
@@ -7,7 +7,6 @@ MLDatasets = "eb30cadb-4394-5ae3-aed4-317e484a6458"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
-CUDA = "2.4.0, 3"
-Flux = "0.13.9"
+Flux = "0.13.9, 0.14"
 MLDatasets = "0.7"
 julia = "1.6"

--- a/vision/mlp_mnist/Project.toml
+++ b/vision/mlp_mnist/Project.toml
@@ -7,6 +7,6 @@ Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
-Flux = "0.13.9"
+Flux = "0.13.9, 0.14"
 MLDatasets = "0.7"
 julia = "1.6"

--- a/vision/spatial_transformer/Project.toml
+++ b/vision/spatial_transformer/Project.toml
@@ -13,6 +13,6 @@ ZygoteRules = "700de1a5-db45-46bc-99cf-38207098b444"
 
 [compat]
 DrWatson = "2.7.6"
-Flux = "0.13.9"
+Flux = "0.13.9, 0.14"
 MLDatasets = "0.7.6"
 julia = "1.7.0"

--- a/vision/vae_mnist/Project.toml
+++ b/vision/vae_mnist/Project.toml
@@ -12,7 +12,7 @@ ProgressMeter = "92933f4c-e287-5a05-a399-4b506db050ca"
 TensorBoardLogger = "899adc3e-224a-11e9-021f-63837185c80f"
 
 [compat]
-CUDA = "2.4, 3.12"
-Flux = "0.13.9"
+CUDA = "2.4, 3.12, 4"
+Flux = "0.13.9, 0.14"
 MLDatasets = "0.7"
 julia = "1.6"

--- a/vision/vgg_cifar10/Project.toml
+++ b/vision/vgg_cifar10/Project.toml
@@ -7,8 +7,8 @@ MLUtils = "f1d291b0-491e-4a28-83b9-f70985020b54"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
-CUDA = "3"
-Flux = "0.13.9"
+CUDA = "3, 4"
+Flux = "0.13.9, 0.14"
 MLDatasets = "0.7"
 MLUtils = "0.3"
 julia = "1.6"


### PR DESCRIPTION
This updates Project.toml to allow 0.14, but without updating all the manifests. 